### PR TITLE
distributed rpc tracing for armeria

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,18 @@
       <version>9.3.6.v20151106</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- distributed tracing -->
+    <dependency>
+      <groupId>com.github.kristofa</groupId>
+      <artifactId>brave-core</artifactId>
+      <version>3.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.kristofa</groupId>
+      <artifactId>brave-http</artifactId>
+      <version>3.4.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/linecorp/armeria/client/tracing/ClientTracingInterceptor.java
+++ b/src/main/java/com/linecorp/armeria/client/tracing/ClientTracingInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.tracing;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientRequestAdapter;
+import com.github.kristofa.brave.ClientRequestInterceptor;
+import com.github.kristofa.brave.ClientResponseAdapter;
+import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.ClientSpanThreadBinder;
+import com.twitter.zipkin.gen.Span;
+
+class ClientTracingInterceptor {
+
+    private final ClientRequestInterceptor requestInterceptor;
+
+    private final ClientResponseInterceptor responseInterceptor;
+
+    private final ClientSpanThreadBinder spanThreadBinder;
+
+    ClientTracingInterceptor(Brave brave) {
+        requireNonNull(brave, "brave");
+        requestInterceptor = brave.clientRequestInterceptor();
+        responseInterceptor = brave.clientResponseInterceptor();
+        spanThreadBinder = brave.clientSpanThreadBinder();
+    }
+
+    @Nullable
+    Span openSpan(ClientRequestAdapter adapter) {
+        requestInterceptor.handle(adapter);
+        return spanThreadBinder.getCurrentClientSpan();
+    }
+
+    void closeSpan(Span span, ClientResponseAdapter adapter) {
+        spanThreadBinder.setCurrentSpan(span);
+        responseInterceptor.handle(adapter);
+    }
+
+    void clearSpan() {
+        spanThreadBinder.setCurrentSpan(null);
+    }
+}

--- a/src/main/java/com/linecorp/armeria/client/tracing/TracingRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/tracing/TracingRemoteInvoker.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.tracing;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientRequestAdapter;
+import com.github.kristofa.brave.ClientResponseAdapter;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+
+import com.linecorp.armeria.client.ClientCodec;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.DecoratingRemoteInvoker;
+import com.linecorp.armeria.client.RemoteInvoker;
+
+import io.netty.util.concurrent.Future;
+
+/**
+ * An abstract {@link RemoteInvoker} that traces remote service invocations.
+ * <p/>
+ * This class depends on <a href="https://github.com/openzipkin/brave">brave</a> distributed tracing library.
+ */
+public abstract class TracingRemoteInvoker extends DecoratingRemoteInvoker {
+
+    private final ClientTracingInterceptor clientInterceptor;
+
+    public TracingRemoteInvoker(RemoteInvoker remoteInvoker, Brave brave) {
+        super(remoteInvoker);
+        clientInterceptor = new ClientTracingInterceptor(brave);
+    }
+
+    @Override
+    public <T> Future<T> invoke(URI uri,
+                                ClientOptions options,
+                                ClientCodec codec,
+                                Method method,
+                                Object[] args) throws Exception {
+
+        // create new request adapter to catch generated spanId
+        final InternalClientRequestAdapter requestAdapter = new InternalClientRequestAdapter(method.getName());
+
+        final Span span = clientInterceptor.openSpan(requestAdapter);
+        if (span == null) {
+            // skip tracing
+            return super.invoke(uri, options, codec, method, args);
+        }
+
+        // new client options with trace data
+        final ClientOptions newOptions = putTraceData(options, requestAdapter.getSpanId());
+
+        // The actual remote invocation is done asynchronously.
+        // So we have to clear the span from current thread.
+        clientInterceptor.clearSpan();
+
+        Future<T> result = null;
+        try {
+            result = super.invoke(uri, newOptions, codec, method, args);
+            result.addListener(future -> {
+                clientInterceptor.closeSpan(span,
+                                            createResponseAdapter(uri, options, codec, method, args, future));
+            });
+        } finally {
+            if (result == null) {
+                clientInterceptor.closeSpan(span,
+                                            createResponseAdapter(uri, options, codec, method, args, null));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Puts trace data into the specified base {@link ClientOptions}, returning new instance of
+     * {@link ClientOptions}.
+     */
+    protected abstract ClientOptions putTraceData(ClientOptions baseOptions, @Nullable SpanId spanId);
+
+    /**
+     * Returns client side annotations that should be added to span.
+     */
+    protected <T> List<KeyValueAnnotation> annotations(URI uri, ClientOptions options, ClientCodec codec,
+                                                       Method method, Object[] args,
+                                                       @Nullable Future<? super T> result) {
+
+        final List<KeyValueAnnotation> annotations = new ArrayList<>();
+
+        annotations.add(KeyValueAnnotation.create("client.uri", uri.toString() + '#' + method.getName()));
+
+        if (result != null && result.isDone()) {
+            final String resultText = result.isSuccess() ? "success" : "failure";
+            annotations.add(KeyValueAnnotation.create("client.result", resultText));
+
+            if (result.cause() != null) {
+                annotations.add(KeyValueAnnotation.create("client.cause", result.cause().getMessage()));
+            }
+        }
+
+        return annotations;
+    }
+
+    protected <T> ClientResponseAdapter createResponseAdapter(URI uri, ClientOptions options, ClientCodec codec,
+                                                              Method method, Object[] args,
+                                                              @Nullable Future<? super T> result) {
+
+        final List<KeyValueAnnotation> annotations = annotations(uri, options, codec, method, args, result);
+        return new ClientResponseAdapter() {
+            @Override
+            public Collection<KeyValueAnnotation> responseAnnotations() {
+                return annotations;
+            }
+        };
+    }
+
+    /**
+     * A {@link ClientRequestAdapter} holding a {@link SpanId} that was passed from brave.
+     */
+    private static class InternalClientRequestAdapter implements ClientRequestAdapter {
+
+        private final String spanName;
+
+        private SpanId spanId;
+
+        public InternalClientRequestAdapter(String spanName) {
+            this.spanName = spanName;
+        }
+
+        @Nullable
+        public SpanId getSpanId() {
+            return spanId;
+        }
+
+        @Override
+        public String getSpanName() {
+            return spanName;
+        }
+
+        @Override
+        public void addSpanIdToRequest(@com.github.kristofa.brave.internal.Nullable SpanId spanId) {
+            this.spanId = spanId;
+        }
+
+        @Override
+        public Collection<KeyValueAnnotation> requestAnnotations() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getClientServiceName() {
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/client/tracing/http/HttpTracingClient.java
+++ b/src/main/java/com/linecorp/armeria/client/tracing/http/HttpTracingClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.tracing.http;
+
+import java.util.function.Function;
+
+import com.github.kristofa.brave.Brave;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.DecoratingClient;
+
+/**
+ * A {@link Client} decorator that traces HTTP-based remote service invocations.
+ * <p/>
+ * This decorator puts trace data into HTTP headers. The specifications of header names and its values
+ * correspond to <a href="http://zipkin.io/">zipkin</a>.
+ */
+public class HttpTracingClient extends DecoratingClient {
+
+    /**
+     * Creates a new instance that decorates the specified {@link Client} with the specified {@link Brave}
+     * instance.
+     */
+    public static HttpTracingClient of(Client client, Brave brave) {
+        return new HttpTracingClient(client, brave);
+    }
+
+    HttpTracingClient(Client client, Brave brave) {
+        super(client, Function.identity(), remoteInvoker -> new HttpTracingRemoteInvoker(remoteInvoker, brave));
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/client/tracing/http/HttpTracingRemoteInvoker.java
+++ b/src/main/java/com/linecorp/armeria/client/tracing/http/HttpTracingRemoteInvoker.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.tracing.http;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+
+import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.RemoteInvoker;
+import com.linecorp.armeria.client.tracing.TracingRemoteInvoker;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+
+/**
+ * A {@link TracingRemoteInvoker} that uses HTTP headers as a container of trace data.
+ */
+class HttpTracingRemoteInvoker extends TracingRemoteInvoker {
+
+    HttpTracingRemoteInvoker(RemoteInvoker remoteInvoker, Brave brave) {
+        super(remoteInvoker, brave);
+    }
+
+    @Override
+    protected ClientOptions putTraceData(ClientOptions baseOptions, @Nullable SpanId spanId) {
+        final HttpHeaders headers = new DefaultHttpHeaders();
+
+        final Optional<HttpHeaders> baseHttpHeaders = baseOptions.get(ClientOption.HTTP_HEADERS);
+        if (baseHttpHeaders.isPresent()) {
+            headers.add(baseHttpHeaders.get());
+        }
+
+        if (spanId == null) {
+            headers.add(BraveHttpHeaders.Sampled.getName(), "0");
+        } else {
+            headers.add(BraveHttpHeaders.Sampled.getName(), "1");
+            headers.add(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.getTraceId()));
+            headers.add(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.getSpanId()));
+            if (spanId.getParentSpanId() != null) {
+                headers.add(BraveHttpHeaders.ParentSpanId.getName(),
+                            IdConversion.convertToString(spanId.getParentSpanId()));
+            }
+        }
+
+        return ClientOptions.of(baseOptions, ClientOption.HTTP_HEADERS.newValue(headers));
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/server/tracing/ServerTracingInterceptor.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/ServerTracingInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.tracing;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerRequestAdapter;
+import com.github.kristofa.brave.ServerRequestInterceptor;
+import com.github.kristofa.brave.ServerResponseAdapter;
+import com.github.kristofa.brave.ServerResponseInterceptor;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.ServerTracer;
+
+class ServerTracingInterceptor {
+
+    private final ServerTracer serverTracer;
+
+    private final ServerRequestInterceptor requestInterceptor;
+
+    private final ServerResponseInterceptor responseInterceptor;
+
+    private final ServerSpanThreadBinder spanThreadBinder;
+
+    ServerTracingInterceptor(Brave brave) {
+        requireNonNull(brave, "brave");
+        serverTracer = brave.serverTracer();
+        requestInterceptor = brave.serverRequestInterceptor();
+        responseInterceptor = brave.serverResponseInterceptor();
+        spanThreadBinder = brave.serverSpanThreadBinder();
+    }
+
+    @Nullable
+    ServerSpan openSpan(ServerRequestAdapter adapter) {
+        requestInterceptor.handle(adapter);
+        return spanThreadBinder.getCurrentServerSpan();
+    }
+
+    void closeSpan(ServerSpan span, ServerResponseAdapter adapter) {
+        spanThreadBinder.setCurrentSpan(span);
+        responseInterceptor.handle(adapter);
+    }
+
+    void clearSpan() {
+        serverTracer.clearCurrentSpan();
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandler.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.tracing;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.ServerRequestAdapter;
+import com.github.kristofa.brave.ServerResponseAdapter;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.TraceData;
+
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.server.DecoratingServiceInvocationHandler;
+import com.linecorp.armeria.server.ServiceInvocationHandler;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * An abstract {@link ServiceInvocationHandler} that traces service invocations.
+ * <p/>
+ * This class depends on <a href="https://github.com/openzipkin/brave">brave</a> distributed tracing library.
+ */
+public abstract class TracingServiceInvocationHandler extends DecoratingServiceInvocationHandler {
+
+    private final ServerTracingInterceptor serverInterceptor;
+
+    protected TracingServiceInvocationHandler(ServiceInvocationHandler handler, Brave brave) {
+        super(handler);
+        serverInterceptor = new ServerTracingInterceptor(brave);
+    }
+
+    @Override
+    public void invoke(ServiceInvocationContext ctx,
+                       Executor blockingTaskExecutor,
+                       Promise<Object> promise) throws Exception {
+
+        final TraceData traceData = getTraceData(ctx);
+        if (traceData != null && traceData.getSample()) {
+            final ServerRequestAdapter requestAdapter =
+                    new InternalServerRequestAdapter(ctx.method(), traceData);
+
+            final ServerSpan span = serverInterceptor.openSpan(requestAdapter);
+            if (span != null && span.getSample()) {
+                promise.addListener(future -> {
+                    serverInterceptor.closeSpan(span, createResponseAdapter(ctx, future));
+                });
+            }
+        }
+        try {
+            super.invoke(ctx, blockingTaskExecutor, promise);
+        } finally {
+            serverInterceptor.clearSpan();
+        }
+    }
+
+    /**
+     * Gets a {@link TraceData} from the specified {@link ServiceInvocationContext}.
+     *
+     * @return the {@link TraceData}, or null if the {@link ServiceInvocationContext} is not traceable.
+     */
+    @Nullable
+    protected abstract TraceData getTraceData(ServiceInvocationContext ctx);
+
+    /**
+     * Returns server side annotations that should be added to span.
+     */
+    protected <T> List<KeyValueAnnotation> annotations(ServiceInvocationContext ctx, Future<? super T> result) {
+        final List<KeyValueAnnotation> annotations = new ArrayList<>();
+
+        final StringBuilder uriBuilder = new StringBuilder();
+        uriBuilder.append(ctx.scheme() != null ? ctx.scheme().uriText() : "unknown");
+        uriBuilder.append("://");
+        uriBuilder.append(ctx.host() != null ? ctx.host() : "<unknown-host>");
+        uriBuilder.append(ctx.path() != null ? ctx.path() : "/<unknown-path>");
+        if (ctx.method() != null) {
+            uriBuilder.append('#');
+            uriBuilder.append(ctx.method());
+        }
+        annotations.add(KeyValueAnnotation.create("server.uri", uriBuilder.toString()));
+
+        if (ctx.remoteAddress() != null) {
+            annotations.add(KeyValueAnnotation.create("server.remote", ctx.remoteAddress().toString()));
+        }
+
+        if (ctx.localAddress() != null) {
+            annotations.add(KeyValueAnnotation.create("server.local", ctx.localAddress().toString()));
+        }
+
+        if (result != null && result.isDone()) {
+            final String resultText = result.isSuccess() ? "success" : "failure";
+            annotations.add(KeyValueAnnotation.create("server.result", resultText));
+
+            if (result.cause() != null) {
+                annotations.add(KeyValueAnnotation.create("server.cause", result.cause().getMessage()));
+            }
+        }
+        return annotations;
+    }
+
+    protected <T> ServerResponseAdapter createResponseAdapter(ServiceInvocationContext ctx,
+                                                              Future<? super T> result) {
+
+        final List<KeyValueAnnotation> annotations = annotations(ctx, result);
+        return new ServerResponseAdapter() {
+            @Override
+            public Collection<KeyValueAnnotation> responseAnnotations() {
+                return annotations;
+            }
+        };
+    }
+
+    /**
+     * A {@link ServerRequestAdapter} holding span name and {@link TraceData} that will be passed to brave.
+     */
+    private static class InternalServerRequestAdapter implements ServerRequestAdapter {
+
+        private final String spanName;
+
+        private final TraceData traceData;
+
+        public InternalServerRequestAdapter(String spanName, TraceData traceData) {
+            this.spanName = spanName;
+            this.traceData = traceData;
+        }
+
+        @Override
+        public TraceData getTraceData() {
+            return traceData;
+        }
+
+        @Override
+        public String getSpanName() {
+            return spanName;
+        }
+
+        @Override
+        public Collection<KeyValueAnnotation> requestAnnotations() {
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/src/main/java/com/linecorp/armeria/server/tracing/http/HttpTracingService.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/http/HttpTracingService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.tracing.http;
+
+import java.util.function.Function;
+
+import com.github.kristofa.brave.Brave;
+
+import com.linecorp.armeria.server.DecoratingService;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * A {@link Service} decorator that traces HTTP-based service invocations.
+ * <p/>
+ * This decorator retrieves trace data from HTTP headers. The specifications of header names and its values
+ * correspond to <a href="http://zipkin.io/">zipkin</a>.
+ */
+public class HttpTracingService extends DecoratingService {
+
+    /**
+     * Creates a new instance that decorates the specified {@link Service} with the specified {@link Brave}
+     * instance.
+     */
+    public static HttpTracingService of(Service service, Brave brave) {
+        return new HttpTracingService(service, brave);
+    }
+
+    HttpTracingService(Service service, Brave brave) {
+        super(service, Function.identity(), handler -> new HttpTracingServiceInvocationHandler(handler, brave));
+    }
+}

--- a/src/main/java/com/linecorp/armeria/server/tracing/http/HttpTracingServiceInvocationHandler.java
+++ b/src/main/java/com/linecorp/armeria/server/tracing/http/HttpTracingServiceInvocationHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.tracing.http;
+
+import javax.annotation.Nullable;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceData;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.server.ServiceInvocationHandler;
+import com.linecorp.armeria.server.tracing.TracingServiceInvocationHandler;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+
+/**
+ * A {@link TracingServiceInvocationHandler} that uses HTTP headers as a container of trace data.
+ */
+class HttpTracingServiceInvocationHandler extends TracingServiceInvocationHandler {
+
+    HttpTracingServiceInvocationHandler(ServiceInvocationHandler handler, Brave brave) {
+        super(handler, brave);
+    }
+
+    @Override
+    @Nullable
+    protected TraceData getTraceData(ServiceInvocationContext ctx) {
+        final Object request = ctx.originalRequest();
+        if (request != null && request instanceof DefaultHttpRequest) {
+            final HttpHeaders headers = ((DefaultHttpRequest) request).headers();
+
+            // The following HTTP trace header spec is based on
+            // com.github.kristofa.brave.http.HttpServerRequestAdapter#getTraceData
+
+            final String sampled = headers.get(BraveHttpHeaders.Sampled.getName());
+            if ("1".equals(sampled)) {
+                final String traceId = headers.get(BraveHttpHeaders.TraceId.getName());
+                final String spanId = headers.get(BraveHttpHeaders.SpanId.getName());
+                if (traceId != null && spanId != null) {
+                    final String parentSpanId = headers.get(BraveHttpHeaders.ParentSpanId.getName());
+                    final SpanId span = getSpanId(traceId, spanId, parentSpanId);
+                    return TraceData.builder().sample(true).spanId(span).build();
+                }
+            } else {
+                return TraceData.builder().sample(false).build();
+            }
+        }
+        return null; // The request is not traceable
+    }
+
+    private SpanId getSpanId(String traceId, String spanId, String parentSpanId) {
+        if (parentSpanId != null) {
+            return SpanId.create(IdConversion.convertToLong(traceId),
+                                 IdConversion.convertToLong(spanId),
+                                 IdConversion.convertToLong(parentSpanId));
+        }
+        return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), null);
+    }
+
+}

--- a/src/test/java/com/linecorp/armeria/client/tracing/TracingRemoteInvokerTest.java
+++ b/src/test/java/com/linecorp/armeria/client/tracing/TracingRemoteInvokerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.tracing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.Sampler;
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.Span;
+
+import com.linecorp.armeria.client.ClientCodec;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.RemoteInvoker;
+import com.linecorp.armeria.common.tracing.TracingTestBase;
+
+import io.netty.util.concurrent.Future;
+
+public class TracingRemoteInvokerTest extends TracingTestBase {
+
+    private static final String TEST_SERVICE = "testservice";
+
+    private static final String TEST_SPAN = "serve";
+
+    @Test
+    public void shouldSubmitSpanWhenSampled() throws Exception {
+        StubCollector spanCollector = testRemoteInvocationWithSamplingRate(1.0f);
+
+        // only one span should be submitted
+        assertThat(spanCollector.spans, hasSize(1));
+
+        // check span name
+        Span span = spanCollector.spans.get(0);
+        assertThat(span.name, is(TEST_SPAN));
+
+        // check # of annotations
+        List<Annotation> annotations = span.annotations;
+        assertThat(annotations, hasSize(2));
+
+        // check annotation values
+        List<String> values = annotations.stream().map(anno -> anno.value).collect(Collectors.toList());
+        assertThat(values, is(containsInAnyOrder("cs", "cr")));
+
+        // check service name
+        List<String> serviceNames = annotations.stream()
+                                               .map(anno -> anno.getHost().getService_name())
+                                               .collect(Collectors.toList());
+        assertThat(serviceNames, is(contains(TEST_SERVICE, TEST_SERVICE)));
+    }
+
+    @Test
+    public void shouldNotSubmitSpanWhenNotSampled() throws Exception {
+        StubCollector spanCollector = testRemoteInvocationWithSamplingRate(0.0f);
+
+        assertThat(spanCollector.spans, hasSize(0));
+    }
+
+    private static StubCollector testRemoteInvocationWithSamplingRate(float samplingRate) throws Exception {
+        StubCollector spanCollector = new StubCollector();
+
+        Brave brave = new Brave.Builder(TEST_SERVICE)
+                .spanCollector(spanCollector)
+                .traceSampler(Sampler.create(samplingRate))
+                .build();
+
+        Future<Object> mockFut = mockFuture();
+
+        RemoteInvoker remoteInvoker = mock(RemoteInvoker.class);
+        when(remoteInvoker.invoke(any(), any(), any(), any(), any())).thenReturn(mockFut);
+
+        TracingRemoteInvoker stub = new TracingRemoteInvokerImpl(remoteInvoker, brave);
+
+        // prepare parameters
+        URI uri = new URI("http://xxx");
+        ClientOptions options = ClientOptions.of();
+        ClientCodec codec = mock(ClientCodec.class);
+        Method method = getServiceMethod();
+        Object[] args = { "a", "b" };
+
+        // do invoke
+        Future<Object> resultFut = stub.invoke(uri, options, codec, method, args);
+
+        assertThat(resultFut, is(mockFut));
+
+        verify(remoteInvoker, times(1)).invoke(eq(uri), anyObject(), eq(codec), eq(method), eq(args));
+
+        return spanCollector;
+    }
+
+    private static class TracingRemoteInvokerImpl extends TracingRemoteInvoker {
+
+        TracingRemoteInvokerImpl(RemoteInvoker remoteInvoker, Brave brave) {
+            super(remoteInvoker, brave);
+        }
+
+        @Override
+        protected ClientOptions putTraceData(ClientOptions baseOptions, SpanId spanId) {
+            return null;
+        }
+    }
+
+}

--- a/src/test/java/com/linecorp/armeria/client/tracing/http/HttpTracingRemoteInvokerTest.java
+++ b/src/test/java/com/linecorp/armeria/client/tracing/http/HttpTracingRemoteInvokerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.tracing.http;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.github.kristofa.brave.Brave;
+
+import com.linecorp.armeria.client.ClientOption;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.RemoteInvoker;
+import com.linecorp.armeria.common.tracing.http.HttpTracingTestBase;
+
+import io.netty.handler.codec.http.HttpHeaders;
+
+public class HttpTracingRemoteInvokerTest extends HttpTracingTestBase {
+
+    private static final HttpTracingRemoteInvoker remoteInvoker =
+            new HttpTracingRemoteInvoker(mock(RemoteInvoker.class), mock(Brave.class));
+
+    @Test
+    public void testPutTraceData() {
+        HttpHeaders baseHeaders = otherHeaders();
+        ClientOptions baseOptions = ClientOptions.of(ClientOption.HTTP_HEADERS.newValue(baseHeaders));
+
+        ClientOptions newOptions = remoteInvoker.putTraceData(baseOptions, testSpanId);
+
+        HttpHeaders expectedHeaders = traceHeaders().add(otherHeaders());
+        assertThat(newOptions.get(ClientOption.HTTP_HEADERS), is(Optional.of(expectedHeaders)));
+    }
+
+    @Test
+    public void testPutTraceDataIfSpanIsNull() {
+        HttpHeaders baseHeaders = otherHeaders();
+        ClientOptions baseOptions = ClientOptions.of(ClientOption.HTTP_HEADERS.newValue(baseHeaders));
+
+        ClientOptions newOptions = remoteInvoker.putTraceData(baseOptions, null);
+
+        HttpHeaders expectedHeaders = traceHeadersNotSampled().add(otherHeaders());
+        assertThat(newOptions.get(ClientOption.HTTP_HEADERS), is(Optional.of(expectedHeaders)));
+    }
+}

--- a/src/test/java/com/linecorp/armeria/common/tracing/TracingTestBase.java
+++ b/src/test/java/com/linecorp/armeria/common/tracing/TracingTestBase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.tracing;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.kristofa.brave.SpanCollector;
+import com.twitter.zipkin.gen.Span;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
+
+public abstract class TracingTestBase {
+
+    public static class StubCollector implements SpanCollector {
+
+        public final List<Span> spans = new ArrayList<>();
+
+        @Override
+        public void collect(Span span) {
+            spans.add(span);
+        }
+
+        @Override
+        public void addDefaultAnnotation(String s, String s1) {
+        }
+    }
+
+    public static class Service {
+
+        public void serve() {
+        }
+    }
+
+    public static Method getServiceMethod() throws NoSuchMethodException {
+        return Service.class.getMethod("serve");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Future<T> mockFuture() {
+        Future<T> future = (Future<T>) mock(Future.class);
+        when(future.addListener(any())).then(invoc -> {
+            GenericFutureListener<Future<T>> listener = invoc.getArgumentAt(0, GenericFutureListener.class);
+            listener.operationComplete(future);
+            return future;
+        });
+        return future;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Promise<T> mockPromise() {
+        Promise<T> promise = (Promise<T>) mock(Promise.class);
+        when(promise.addListener(any())).then(invoc -> {
+            GenericFutureListener<Future<T>> listener = invoc.getArgumentAt(0, GenericFutureListener.class);
+            listener.operationComplete(promise);
+            return promise;
+        });
+        return promise;
+    }
+}

--- a/src/test/java/com/linecorp/armeria/common/tracing/http/HttpTracingTestBase.java
+++ b/src/test/java/com/linecorp/armeria/common/tracing/http/HttpTracingTestBase.java
@@ -1,0 +1,38 @@
+package com.linecorp.armeria.common.tracing.http;
+
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+
+public abstract class HttpTracingTestBase {
+
+    public static final SpanId testSpanId = SpanId.create(1, 2, 3L);
+
+    public static HttpHeaders traceHeaders() {
+        HttpHeaders httpHeader = new DefaultHttpHeaders();
+        httpHeader.add(BraveHttpHeaders.Sampled.getName(), "1");
+        httpHeader.add(BraveHttpHeaders.TraceId.getName(), "1");
+        httpHeader.add(BraveHttpHeaders.SpanId.getName(), "2");
+        httpHeader.add(BraveHttpHeaders.ParentSpanId.getName(), "3");
+        return httpHeader;
+    }
+
+    public static HttpHeaders otherHeaders() {
+        HttpHeaders httpHeader = new DefaultHttpHeaders();
+        httpHeader.add("X-TEST-HEADER", "xtestheader");
+        return httpHeader;
+    }
+
+    public static HttpHeaders traceHeadersNotSampled() {
+        HttpHeaders httpHeader = new DefaultHttpHeaders();
+        httpHeader.add(BraveHttpHeaders.Sampled.getName(), "0");
+        return httpHeader;
+    }
+
+    public static HttpHeaders emptyHttpHeaders() {
+        return new DefaultHttpHeaders();
+    }
+
+}

--- a/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/tracing/TracingServiceInvocationHandlerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.tracing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.Sampler;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceData;
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.Span;
+
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.tracing.TracingTestBase;
+import com.linecorp.armeria.server.ServiceInvocationHandler;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+public class TracingServiceInvocationHandlerTest extends TracingTestBase {
+
+    private static final String TEST_SERVICE = "testservice";
+
+    private static final String TEST_SPAN = "testspan";
+
+    @Test
+    public void shouldSubmitSpanWhenRequestIsSampled() throws Exception {
+        StubCollector spanCollector = testServiceInvocation(true /* sampled */);
+
+        // only one span should be submitted
+        assertThat(spanCollector.spans, hasSize(1));
+
+        // check span name
+        Span span = spanCollector.spans.get(0);
+        assertThat(span.name, is(TEST_SPAN));
+
+        // check # of annotations
+        List<Annotation> annotations = span.annotations;
+        assertThat(annotations, hasSize(2));
+
+        // check annotation values
+        List<String> values = annotations.stream().map(anno -> anno.value).collect(Collectors.toList());
+        assertThat(values, is(containsInAnyOrder("sr", "ss")));
+
+        // check service name
+        List<String> serviceNames = annotations.stream()
+                                               .map(anno -> anno.getHost().getService_name())
+                                               .collect(Collectors.toList());
+        assertThat(serviceNames, is(contains(TEST_SERVICE, TEST_SERVICE)));
+    }
+
+    @Test
+    public void shouldNotSubmitSpanWhenRequestIsNotSampled() throws Exception {
+        StubCollector spanCollector = testServiceInvocation(false /* not sampled */);
+
+        // don't submit any spans
+        assertThat(spanCollector.spans, hasSize(0));
+    }
+
+    private static StubCollector testServiceInvocation(boolean sampled) throws Exception {
+        StubCollector spanCollector = new StubCollector();
+
+        Brave brave = new Brave.Builder(TEST_SERVICE)
+                .spanCollector(spanCollector)
+                .traceSampler(Sampler.create(1.0f))
+                .build();
+
+        ServiceInvocationHandler serviceInvocationHandler = mock(ServiceInvocationHandler.class);
+
+        TraceData traceData = TraceData.builder().sample(sampled).spanId(SpanId.create(1, 2, 3L)).build();
+
+        TracingServiceInvocationHandlerImpl stub = new TracingServiceInvocationHandlerImpl(
+                serviceInvocationHandler, brave, traceData);
+
+        ServiceInvocationContext ctx = mock(ServiceInvocationContext.class);
+        when(ctx.method()).thenReturn(TEST_SPAN);
+        Executor executor = mock(Executor.class);
+        Promise<Object> promise = mockPromise();
+
+        // do invoke
+        stub.invoke(ctx, executor, promise);
+
+        verify(serviceInvocationHandler, times(1)).invoke(eq(ctx), eq(executor), eq(promise));
+        return spanCollector;
+    }
+
+    private static class TracingServiceInvocationHandlerImpl extends TracingServiceInvocationHandler {
+
+        private final TraceData traceData;
+
+        public TracingServiceInvocationHandlerImpl(ServiceInvocationHandler serviceInvocationHandler,
+                                                   Brave brave,
+                                                   TraceData traceData) {
+            super(serviceInvocationHandler, brave);
+            this.traceData = traceData;
+        }
+
+        @Override
+        protected TraceData getTraceData(ServiceInvocationContext ctx) {
+            return traceData;
+        }
+
+        @Override
+        protected <T> List<KeyValueAnnotation> annotations(ServiceInvocationContext ctx,
+                                                           @Nullable Future<? super T> result) {
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/src/test/java/com/linecorp/armeria/server/tracing/http/HttpTracingServiceInvocationHandlerTest.java
+++ b/src/test/java/com/linecorp/armeria/server/tracing/http/HttpTracingServiceInvocationHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.tracing.http;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.TraceData;
+
+import com.linecorp.armeria.common.ServiceInvocationContext;
+import com.linecorp.armeria.common.tracing.http.HttpTracingTestBase;
+import com.linecorp.armeria.server.ServiceInvocationHandler;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class HttpTracingServiceInvocationHandlerTest extends HttpTracingTestBase {
+
+    private static final HttpTracingServiceInvocationHandler serviceInvocationHandler =
+            new HttpTracingServiceInvocationHandler(
+                    mock(ServiceInvocationHandler.class), mock(Brave.class));
+
+    @Test
+    public void testGetTraceData() {
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
+        httpRequest.headers().add(traceHeaders());
+
+        ServiceInvocationContext ctx = mock(ServiceInvocationContext.class);
+        when(ctx.originalRequest()).thenReturn(httpRequest);
+
+        TraceData traceData = serviceInvocationHandler.getTraceData(ctx);
+        assertThat(traceData.getSpanId(), is(testSpanId));
+        assertThat(traceData.getSample(), is(true));
+    }
+
+    @Test
+    public void testGetTraceDataIfRequestIsNotTraceable() {
+        ServiceInvocationContext ctx = mock(ServiceInvocationContext.class);
+        when(ctx.originalRequest()).thenReturn(new Object());
+
+        TraceData traceData = serviceInvocationHandler.getTraceData(ctx);
+        assertThat(traceData, is(nullValue()));
+    }
+
+    @Test
+    public void testGetTraceDataIfRequestIsNotContainTraceData() {
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
+        httpRequest.headers().add(emptyHttpHeaders());
+
+        ServiceInvocationContext ctx = mock(ServiceInvocationContext.class);
+        when(ctx.originalRequest()).thenReturn(httpRequest);
+
+        TraceData traceData = serviceInvocationHandler.getTraceData(ctx);
+        assertThat(traceData.getSample(), is(false));
+    }
+
+    @Test
+    public void testGetTraceDataIfRequestIsNotSampled() {
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
+        httpRequest.headers().add(traceHeadersNotSampled());
+
+        ServiceInvocationContext ctx = mock(ServiceInvocationContext.class);
+        when(ctx.originalRequest()).thenReturn(httpRequest);
+
+        TraceData traceData = serviceInvocationHandler.getTraceData(ctx);
+        assertThat(traceData.getSpanId(), is(nullValue()));
+        assertThat(traceData.getSample(), is(false));
+    }
+
+}


### PR DESCRIPTION
Introduces distributed tracing capability to armeria clients/servers. This enables you to watch timing data among the whole rpc chain. 

This feature depends on [brave](https://github.com/openzipkin/brave) distributed tracing library compatible with [zipkin](http://zipkin.io/).
### Setup client

``` java
// Create a brave instance with service name, span collector, sampling rate.
Brave brave = new Brave.Builder("FibClientMain")
        .spanCollector(new ScribeSpanCollector("127.0.0.1", 9410))
        .traceSampler(Sampler.create(0.01f))
        .build();

FibService.Iface fibClient =
        new ClientBuilder("tbinary+http://127.0.0.1:8080/thrift/fib")
                .decorator(client -> HttpTracingClient.of(client, brave))
                .build(FibService.Iface.class);
```
### Setup server

``` java
// Create a brave instance with service name, span collector, sampling rate.
Brave brave = new Brave.Builder("FibServerMain")
        .spanCollector(new ScribeSpanCollector("127.0.0.1", 9410))
        .traceSampler(Sampler.create(0.01f))
        .build();

ServerBuilder builder = new ServerBuilder();

builder.port(8080, SessionProtocol.HTTP);

VirtualHost vh = new VirtualHostBuilder()
        .serviceAt("/thrift/fib",
                ThriftService.of(new FibServiceHandler(brave))
                             .decorate(service -> HttpTracingService.of(service, brave))
        )
        .build();

```
### Custom annotations

``` java
// Add custom attribute to the span in service handler
brave.serverTracer().submitBinaryAnnotation("foo", "bar");

// Add custom timing tag in server handler
brave.serverTracer().submitAnnotation("somethinghappen");
```
